### PR TITLE
Fix startup script to set configuration using piaware-config.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -8,13 +8,9 @@ if [ -z "${BEAST_PORT_30005_TCP_ADDR}" ]; then
   exit 1
 fi
 
-echo "user: $1" > /root/.piaware
-echo "password: $2" >> /root/.piaware
-if [ "yes" = "${MLAT}" ]; then
-  echo "mlat: 1" >> /root/.piaware
-elif [ "no" = "${MLAT}" ]; then
-  echo "mlat: 0" >> /root/.piaware
-fi
+/usr/bin/piaware-config flightaware-user "$1"
+/usr/bin/piaware-config flightaware-password "$2"
+/usr/bin/piaware-config allow-mlat "${MLAT}"
 
 socat TCP-LISTEN:30005,fork TCP:${BEAST_PORT_30005_TCP_ADDR}:${BEAST_PORT_30005_TCP_PORT:-30005} &
 /usr/bin/piaware -debug


### PR DESCRIPTION
The runtime configuration files for piaware [have been deprecated](https://github.com/flightaware/piaware/commit/2a6eb33d77ac81f8bdad809c404c08640e0dc230) and no longer work, we should be setting these values with the dedicated [piaware-config](https://github.com/flightaware/piaware#piaware-config-program) tool.