### PR TITLE
Allow setting of feeder-id with environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
  * Beast data feed (for instance [mradochonski/dump1090-docker](https://hub.docker.com/r/mradochonski/dump1090-docker))
 
 ### Running
-`docker run --link dump1090:beast --mac-address=<mac address> wnagele/piaware <flightaware user> <flightaware password>`
+`docker run --link dump1090:beast --env FEEDER_ID=<feeder id> wnagele/piaware <flightaware user> <flightaware password>`
 
 ### Configuration
-Docker normally assigns a random MAC address every time a container is created. As Flightaware uses your MAC to identify a receiver you have to use the mac-address option to keep it consistent. You can choose any random MAC for this, just keep it the same once you have choosen one.
+Flightaware normally assigns a random feeder ID every time a Piaware site connects to it. As Flightaware uses this ID to identify a receiver you have to use the FEEDER\_ID environment variable to keep it consistent. Running this for the first time omit the FEEDER\_ID variable and find the "Site identifier" value shown on Flightaware MyADSB page. For all subsequent invocations use this value as your FEEDER\_ID.
 
 ### Environment variables
 Use `BEAST_PORT_30005_TCP_ADDR` and `BEAST_PORT_30005_TCP_PORT` to configure the connection details for the Beast data feed. If you link in a container named `beast` that exposes port 30005 these will be set by Docker directly.

--- a/start.sh
+++ b/start.sh
@@ -16,5 +16,9 @@ elif [ "no" = "${MLAT}" ]; then
   echo "mlat: 0" >> /root/.piaware
 fi
 
+if [ -n "${FEEDER_ID}" ]; then
+  /usr/bin/piaware-config feeder-id "${FEEDER_ID}"
+fi
+
 socat TCP-LISTEN:30005,fork TCP:${BEAST_PORT_30005_TCP_ADDR}:${BEAST_PORT_30005_TCP_PORT:-30005} &
 /usr/bin/piaware -debug


### PR DESCRIPTION
Piaware feeders are now identified by Feeder IDs, instead of MAC addresses. Allow setting the feeder-id via environment variable and update references.

https://discussions.flightaware.com/t/how-piaware-feeders-are-identified-updated-2017-07-16/19811