### PR TITLE
Allow setting of Flightaware credentials by environment variable.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
-if [ -z "$2" ]; then
-  echo "Missing arguments: <flightaware user> <flightaware password>"
+if [ "$#" -eq 2 ]; then
+  FLIGHTAWARE_USER="$1"
+  FLIGHTAWARE_PASS="$2"
+elif [ "$#" -gt 2 ]; then
+  echo "Too many arguments. Usage: [<flightaware user> <flightaware password>]"
+  exit 1
+elif [ "$#" -gt 0 ]; then
+  echo "Too few arguments. Usage: [<flightaware user> <flightaware password>]"
   exit 1
 fi
 if [ -z "${BEAST_PORT_30005_TCP_ADDR}" ]; then
@@ -8,9 +14,9 @@ if [ -z "${BEAST_PORT_30005_TCP_ADDR}" ]; then
   exit 1
 fi
 
-/usr/bin/piaware-config flightaware-user "$1"
-/usr/bin/piaware-config flightaware-password "$2"
-/usr/bin/piaware-config allow-mlat "${MLAT}"
+/usr/bin/piaware-config flightaware-user "${FLIGHTAWARE_USER:?}"
+/usr/bin/piaware-config flightaware-password "${FLIGHTAWARE_PASS:?}"
+/usr/bin/piaware-config allow-mlat "${MLAT:=no}"
 
 socat TCP-LISTEN:30005,fork TCP:${BEAST_PORT_30005_TCP_ADDR}:${BEAST_PORT_30005_TCP_PORT:-30005} &
 /usr/bin/piaware -debug

--- a/start.sh
+++ b/start.sh
@@ -8,13 +8,9 @@ if [ -z "${BEAST_PORT_30005_TCP_ADDR}" ]; then
   exit 1
 fi
 
-echo "user: $1" > /root/.piaware
-echo "password: $2" >> /root/.piaware
-if [ "yes" = "${MLAT}" ]; then
-  echo "mlat: 1" >> /root/.piaware
-elif [ "no" = "${MLAT}" ]; then
-  echo "mlat: 0" >> /root/.piaware
-fi
+/usr/bin/piaware-config flightaware-user "$1"
+/usr/bin/piaware-config flightaware-password "$2"
+/usr/bin/piaware-config allow-mlat "${MLAT}"
 
 socat TCP-LISTEN:30005,fork TCP:${BEAST_PORT_30005_TCP_ADDR}:${BEAST_PORT_30005_TCP_PORT:-30005} &
 /usr/bin/piaware -debug


### PR DESCRIPTION
Commit maintains ability to set credentials the old way, on the command line.

Setting login credentials with env. variables allows us to use a separate env_file with docker-compose.

Depends on https://github.com/wnagele/docker-piaware/pull/2,