### PR TITLE
Disable Piaware debug mode.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -17,4 +17,4 @@ elif [ "no" = "${MLAT}" ]; then
 fi
 
 socat TCP-LISTEN:30005,fork TCP:${BEAST_PORT_30005_TCP_ADDR}:${BEAST_PORT_30005_TCP_PORT:-30005} &
-/usr/bin/piaware -debug
+/usr/bin/piaware


### PR DESCRIPTION
Debug mode causes lots of messages to be output to stderr, spamming Docker logs.