### PR TITLE
Install devscripts package to run piaware_builder.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt update && apt install -y \
   autoconf \
   build-essential \
   debhelper \
+  devscripts \
   dh-systemd \
   git \
   libz-dev \


### PR DESCRIPTION
The [dch](https://manpages.debian.org/jessie/devscripts/dch.1.en.html) utility, provided by the [devscripts](https://packages.debian.org/stretch/devscripts) package, is required when running `piaware_builder` as of
https://github.com/flightaware/piaware_builder/commit/b58f98f05b8706dc673c6dea0cc8b915d15bb7d1.