### PR TITLE
Fixes to docker-piaware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ RUN apt update && apt install -y \
   devscripts \
   dh-systemd \
   git \
+  libboost-filesystem-dev \
+  libboost-program-options-dev \
+  libboost-regex-dev \
+  libboost-system-dev \
   libz-dev \
   python3-dev \
   python3-venv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,10 @@ RUN apt update && apt install -y \
   tcl8.6-dev \
   wget
 
-RUN git clone https://github.com/flightaware/piaware_builder.git
-RUN piaware_builder/sensible-build.sh stretch
+RUN git clone https://github.com/flightaware/piaware_builder.git /piaware_builder
+WORKDIR /piaware_builder
+RUN git checkout 8cdcb9edec2b30d47be8bded54c30dc8876b0434
+RUN ./sensible-build.sh stretch
 WORKDIR /piaware_builder/package-stretch
 RUN dpkg-buildpackage -b
 RUN apt install -y ../piaware_*.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt update && apt install -y \
   autoconf \
   build-essential \
   debhelper \
+  devscripts \
   dh-systemd \
   git \
   libz-dev \


### PR DESCRIPTION
Three commits in this PR.

1. Instead devscripts package, now required after https://github.com/wnagele/docker-piaware/commit/c929651fa836a49b215f7d81b83b41f49b8f7f78.

1. Adds libboost dependencies as in #7.

1. Pins github.com/flightaware/piaware_builder at the newest commit in the Dockerfile to help with reproducibility of builds.
   *  We will need to update this from time to time.