### PR TITLE
remove the username/password options, not used

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
  * Beast data feed (for instance [mradochonski/dump1090-docker](https://hub.docker.com/r/mradochonski/dump1090-docker))
 
 ### Running
-`docker run --link dump1090:beast --env FEEDER_ID=<feeder id> wnagele/piaware <flightaware user> <flightaware password>`
+```docker run --link dump1090:beast --env FEEDER_ID=<feeder id> wnagele/piaware```
 
 ### Configuration
-Flightaware normally assigns a random feeder ID every time a Piaware site connects to it. As Flightaware uses this ID to identify a receiver you have to use the FEEDER\_ID environment variable to keep it consistent. Running this for the first time omit the FEEDER\_ID variable and find the "Site identifier" value shown on Flightaware MyADSB page. For all subsequent invocations use this value as your FEEDER\_ID.
+Flightaware normally assigns a random feeder ID (which is a 36-character UUID) every time a Piaware site connects to it. As Flightaware uses this ID to identify a receiver you have to use the `FEEDER_ID` environment variable to keep it consistent.
+
+For the first run, omit the `FEEDER_ID` variable and start this container. [Claim your receiver]() and note the UUID on that page, which is the `FEEDER_ID`. Alternately, after claiming, you may go to your [My ADS-B](https://flightaware.com/adsb/stats/user/) page and find the "Unique Identifier" value. Use this value as your `FEEDER_ID`.
 
 ### Environment variables
 Use `BEAST_PORT_30005_TCP_ADDR` and `BEAST_PORT_30005_TCP_PORT` to configure the connection details for the Beast data feed. If you link in a container named `beast` that exposes port 30005 these will be set by Docker directly.

--- a/start.sh
+++ b/start.sh
@@ -1,21 +1,10 @@
 #!/bin/sh
-if [ "$#" -eq 2 ]; then
-  FLIGHTAWARE_USER="$1"
-  FLIGHTAWARE_PASS="$2"
-elif [ "$#" -gt 2 ]; then
-  echo "Too many arguments. Usage: [<flightaware user> <flightaware password>]"
-  exit 1
-elif [ "$#" -gt 0 ]; then
-  echo "Too few arguments. Usage: [<flightaware user> <flightaware password>]"
-  exit 1
-fi
+
 if [ -z "${BEAST_PORT_30005_TCP_ADDR}" ]; then
   echo "BEAST_PORT_30005_TCP_ADDR environment variable not set"
   exit 1
 fi
 
-/usr/bin/piaware-config flightaware-user "${FLIGHTAWARE_USER:?}"
-/usr/bin/piaware-config flightaware-password "${FLIGHTAWARE_PASS:?}"
 /usr/bin/piaware-config allow-mlat "${MLAT:=no}"
 
 if [ -n "${FEEDER_ID}" ]; then


### PR DESCRIPTION
`piaware-config` [literally doesn't have an option for username or password anymore](https://discussions.flightaware.com/t/password-problem/18918). That can be seen in the code but also in the startup log:

    warning: cannot set option 'flightaware-user', it is not a known config option
    warning: cannot set option 'flightaware-password', it is not a known config option
    Set allow-mlat to yes in /etc/piaware.conf:7
    Set feeder-id to xxx in /etc/piaware.conf:8

I've removed all references to that in the script and the docs. I've also updated the docs, especially around current terminology for getting the Feeder ID.